### PR TITLE
feat: bind api to all addresses

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -64,5 +64,5 @@ pub async fn start_http_server(state: Arc<MinerState>) {
             move || stats_handler(state.clone(), start_time)
         });
 
-    warp::serve(stats_route).run(([127, 0, 0, 1], 8844)).await;
+    warp::serve(stats_route).run(([0, 0, 0, 0], 8844)).await;
 }


### PR DESCRIPTION
Bind the API to all addresses so that one can collect the metrics via e.g. telegraf.